### PR TITLE
chore: Dependabot で依存関係の更新を自動化する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+
+# a-blog cms 本体（Bitbucket）からは submodule として参照されており、依存更新を本体側で
+# まとめて面倒を見るのが難しいため、このリポジトリ自身で自動化する。
+# メジャーを除いているのは、破壊的変更の確認と本体・テーマへの影響評価が必要で、
+# それは人が計画して上げる作業になるため（React 19 の対応がその例）。
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    # パッチとマイナーは 1 本の PR にまとめる。個別に上がると本数が増えるだけで
+    # レビューの単位としては細かすぎるため
+    groups:
+      patch-and-minor:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+    commit-message:
+      prefix: chore
+      include: scope
+
+  # ワークフローが使っている actions も古いままだと CI が動かなくなるため対象に含める
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: monthly
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: ci


### PR DESCRIPTION
## 目的

a-blog cms 本体（Bitbucket）から submodule として参照されているため、依存更新を本体側でまとめて面倒を見るのが難しい。このリポジトリ自身で自動化する。

Bitbucket は Dependabot に対応していないので本体側では使えず、GitHub にあるこのリポジトリだけで設定できる。

## 内容

- npm 依存を**週次**（月曜 9:00 JST）でチェックし、**パッチとマイナーは 1 本の PR にまとめる**
- **メジャーは対象外**。破壊的変更の確認と本体・テーマへの影響評価が必要で、それは人が計画して上げる作業（React 19 対応がその例）
- ワークフローがあるリポジトリでは GitHub Actions 自体も月次で更新

## マージ後に検討したいこと（任意）

Dependabot PR の**自動マージ**まで進めるには、リポジトリ側の設定が別途必要です。

1. CI が `pull_request` でも走るようにする（現状は `on: [push]`）
2. ブランチ保護で CI を必須チェックに設定
3. リポジトリ設定で「Allow auto-merge」を有効化

上記が揃えば `gh pr merge --auto` を使うワークフローを足せます。