### PR TITLE
ci: Dependabot のバージョン更新を production 依存だけに絞る

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
       time: '09:00'
       timezone: Asia/Tokyo
     open-pull-requests-limit: 5
+    # 配布物に入る依存だけを対象にする。開発ツール（eslint / jest / webpack 系）は
+    # 更新しても配布物に影響しない一方、peer の噛み合いが崩れて npm ci が解決不能になり
+    # （実例: eslint-plugin-react-refresh 0.5 が eslint 9 以上を要求）、グループ PR 全体が
+    # 止まる。開発ツールの脆弱性は Dependabot security updates 側で拾われる
+    allow:
+      - dependency-type: production
     groups:
       patch-and-minor:
         patterns:


### PR DESCRIPTION
## 背景

グループ PR（#76「bump the patch-and-minor group with 30 updates」）が CI で BLOCKED になっていました。

```
peer eslint@"^9 || ^10" from eslint-plugin-react-refresh@0.5.3
Found: eslint@8.57.1
```

`eslint-plugin-react-refresh` の 0.4 → 0.5 は Dependabot 上は **minor** 扱いですが、0.x のマイナーは実質破壊的変更で、peer が eslint 9 以上に変わっています。`dependabot.yml` でメジャーを除外していても防げません。そして 30 件を 1 本にまとめているため、**この 1 件で全部が止まります**。

## 変更

`allow: [{ dependency-type: production }]` を追加し、**配布物に入る依存だけ**を対象にします。

- 開発ツール（eslint / jest / webpack 系）は更新しても配布物に影響しない一方、peer の噛み合いでこの種の詰まりを起こします
- 開発ツールの脆弱性は **Dependabot security updates**（`dependabot.yml` とは独立に動く機能）で引き続き拾われます

## あわせて

`#76` はこの設定では作り直されるため閉じます。

なお eslint 8 → 9（flat config 移行）は別途計画したい作業です。移行すれば `eslint-plugin-react-refresh` も追随できます。